### PR TITLE
Add HTTP JSON utility example

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module go_moving
+
+go 1.24.3

--- a/main.go
+++ b/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+// Todo represents a task from the JSONPlaceholder API.
+type Todo struct {
+	UserID    int    `json:"userId"`
+	ID        int    `json:"id"`
+	Title     string `json:"title"`
+	Completed bool   `json:"completed"`
+}
+
+func main() {
+	// Perform GET request to fetch a Todo item.
+	resp, err := http.Get("https://jsonplaceholder.typicode.com/todos/1")
+	if err != nil {
+		log.Fatalf("error fetching todo: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Read response body.
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalf("error reading response: %v", err)
+	}
+
+	// Unmarshal JSON into Todo struct.
+	var todo Todo
+	if err := json.Unmarshal(body, &todo); err != nil {
+		log.Fatalf("error unmarshaling JSON: %v", err)
+	}
+	fmt.Printf("Fetched Todo: %+v\n", todo)
+
+	// Modify the Todo and marshal back to JSON.
+	todo.Completed = true
+	updated, err := json.Marshal(todo)
+	if err != nil {
+		log.Fatalf("error marshaling JSON: %v", err)
+	}
+	fmt.Printf("Updated JSON: %s\n", updated)
+}


### PR DESCRIPTION
## Summary
- add Go module and utility demonstrating HTTP requests and JSON marshalling

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`
- `go build ./...`
- `go run main.go` *(fails: Get "https://jsonplaceholder.typicode.com/todos/1": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a59cac4944832b9457d90125283b26