### PR TITLE
Add context-aware Todo fetcher with tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# Go Moving
+
+This repository contains a small educational program that demonstrates modern
+Go practices such as context-aware HTTP requests, structured error handling and
+unit testing. The application fetches a Todo item from the JSONPlaceholder API,
+modifies it and prints the original and updated versions.
+
+## Getting started
+
+### Prerequisites
+- [Go 1.24+](https://go.dev/dl/)
+
+### Install dependencies
+```bash
+go mod tidy
+```
+
+### Run the program
+```bash
+go run .
+```
+
+## Development
+
+The project follows common Go development workflows:
+
+```bash
+# Format source files
+go fmt ./...
+
+# Run static analysis
+go vet ./...
+
+# Execute tests
+go test ./...
+```
+
+If [golangci-lint](https://golangci-lint.run/) is available, running
+`golangci-lint run` will provide extended linting.
+
+## Project structure
+
+```
+main.go       // Program entry point and high-level orchestration
+todo.go       // Todo type and FetchTodo helper
+todo_test.go  // Unit tests for FetchTodo
+```
+
+## Learning notes
+
+- **Context and timeouts:** `FetchTodo` accepts a `context.Context` and the
+  main function uses `context.WithTimeout` and an HTTP client with a timeout to
+  avoid hanging network calls.
+- **Structured errors:** Errors are wrapped with additional context using
+  `fmt.Errorf` to make troubleshooting easier.
+- **Testing with httptest:** The tests spin up lightweight HTTP servers to
+  simulate API responses, demonstrating effective unit testing of HTTP
+  clients.
+

--- a/todo.go
+++ b/todo.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Todo represents a task returned by the JSONPlaceholder API.
+type Todo struct {
+	UserID    int    `json:"userId"`
+	ID        int    `json:"id"`
+	Title     string `json:"title"`
+	Completed bool   `json:"completed"`
+}
+
+// FetchTodo retrieves a Todo from the provided URL using the supplied HTTP
+// client and context.
+func FetchTodo(ctx context.Context, client *http.Client, url string) (Todo, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return Todo{}, fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return Todo{}, fmt.Errorf("perform request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var todo Todo
+	if err := json.NewDecoder(resp.Body).Decode(&todo); err != nil {
+		return Todo{}, fmt.Errorf("decode response: %w", err)
+	}
+	return todo, nil
+}

--- a/todo_test.go
+++ b/todo_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestFetchTodo(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"userId":1,"id":1,"title":"test","completed":false}`)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	client := &http.Client{Timeout: time.Second}
+	todo, err := FetchTodo(ctx, client, srv.URL)
+	if err != nil {
+		t.Fatalf("FetchTodo returned error: %v", err)
+	}
+	if todo.ID != 1 || todo.Title != "test" || todo.Completed {
+		t.Fatalf("unexpected todo: %+v", todo)
+	}
+}
+
+func TestFetchTodo_DecodeError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "not-json")
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	client := &http.Client{Timeout: time.Second}
+	if _, err := FetchTodo(ctx, client, srv.URL); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- refactor program to fetch Todos using context and timeouts
- add unit tests for FetchTodo using httptest
- document development workflow and modern Go practices in README

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a5ac9d0970832bbd9de859a7c2e6ea